### PR TITLE
Migrar MOSSU a SwiftUI

### DIFF
--- a/MOSSU macos/MOSSUApp.swift
+++ b/MOSSU macos/MOSSUApp.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+@main
+struct MOSSUApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @StateObject private var slackManager = SlackStatusManager()
+
+    init() {
+        appDelegate.slackManager = slackManager
+    }
+
+    var body: some Scene {
+        MenuBarExtra {
+            StatusMenuView(slackManager: slackManager, delegate: appDelegate)
+        } label: {
+            if let office = slackManager.currentOffice {
+                Image(nsImage: office.barIconImage)
+            } else {
+                Image("AppIcon")
+            }
+        }
+        Settings {
+            EmptyView()
+        }
+    }
+}

--- a/MOSSU macos/SlackStatusManager.swift
+++ b/MOSSU macos/SlackStatusManager.swift
@@ -1,22 +1,23 @@
 import Cocoa
 import CoreLocation
+import SwiftUI
 
 protocol SlackStatusManagerDelegate: AnyObject {
     func slackStatusManager(_ manager: SlackStatusManager, didUpdate office: Office?)
     func slackStatusManager(_ manager: SlackStatusManager, showMessage text: String)
 }
 
-class SlackStatusManager: NSObject {
+class SlackStatusManager: NSObject, ObservableObject {
     weak var delegate: SlackStatusManagerDelegate?
-    var name: String = "El muchacho"
-    var paused: Bool = false
-    var lastUpdate: Date?
-    var holidayEndDate: Date?
+    @Published var name: String = "El muchacho"
+    @Published var paused: Bool = false
+    @Published var lastUpdate: Date?
+    @Published var holidayEndDate: Date?
     private var holidayTimer: Timer?
-    var currentOffice: Office? {
+    @Published var currentOffice: Office? {
         didSet { delegate?.slackStatusManager(self, didUpdate: currentOffice) }
     }
-    var token: String? {
+    @Published var token: String? {
         didSet { UserDefaults.standard.set(token, forKey: "token") }
     }
 

--- a/MOSSU macos/StatusMenuView.swift
+++ b/MOSSU macos/StatusMenuView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct StatusMenuView: View {
+    @ObservedObject var slackManager: SlackStatusManager
+    var delegate: AppDelegate
+
+    private var dateFormatter: DateFormatter {
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "es_ES")
+        df.dateStyle = .medium
+        df.timeStyle = .short
+        return df
+    }
+
+    private var dayFormatter: DateFormatter {
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "es_ES")
+        df.dateStyle = .medium
+        df.timeStyle = .none
+        return df
+    }
+
+    var body: some View {
+        Group {
+            if slackManager.token == nil {
+                Button("🔴 Requiere autorización") { delegate.showAuth() }
+                Divider()
+            }
+            if let office = slackManager.currentOffice {
+                Text("\(slackManager.name) está \(office.text)")
+            }
+            let dateString = dateFormatter.string(from: slackManager.lastUpdate ?? Date())
+            Text("Actualizado el \(dateString)")
+            Divider()
+            Button(slackManager.paused ? "▶️ Reanudar actualizaciones" : "⏸️ Pausar actualizaciones") {
+                delegate.pauseOrResumeUpdates()
+            }
+            if let endDate = slackManager.holidayEndDate, slackManager.paused {
+                Text("🌴 Vacaciones hasta \(dayFormatter.string(from: endDate))")
+            } else {
+                Button("🌴 Activar modo vacaciones") { delegate.setHoliday() }
+            }
+            Divider()
+            Button("Buscar actualizaciones…") { delegate.checkForUpdates() }
+            Divider()
+            Button("Salir") { NSApplication.shared.terminate(nil) }
+        }
+        .padding(8)
+    }
+}
+

--- a/MOSSU macos/main.swift
+++ b/MOSSU macos/main.swift
@@ -5,8 +5,4 @@
 //  Created by Javier Querol on 8/7/25.
 //
 
-import Cocoa
-
-let delegate = AppDelegate()
-NSApplication.shared.delegate = delegate
-_ = NSApplicationMain(CommandLine.argc, CommandLine.unsafeArgv)
+// Entry point replaced by SwiftUI in `MOSSUApp.swift`.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ El endpoint `/api/slack/oauth/callback` intercambia el `code` por el token y red
 
 ## Aplicación de macOS
 
-Abre `SSU.xcodeproj` en Xcode y compila el target **MOSSU macos**. La app utiliza el esquema
+Abre `SSU.xcodeproj` en Xcode y compila el target **MOSSU macos**. La interfaz ahora está implementada en **SwiftUI** y la app utiliza el esquema
 personalizado `mossu://oauth` para recibir el token desde el backend anterior.
 El fichero `Constants.swift` contiene los valores por defecto del `client_id`, los scopes y la URL de redirección.
 


### PR DESCRIPTION
## Summary
- convert AppKit entry point to SwiftUI `App`
- expose `SlackStatusManager` as `ObservableObject`
- build new SwiftUI status bar menu
- update README to mention SwiftUI

## Testing
- `npm test`
- `xcodebuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68791f6cd66c8321b5243084a38ae9c8