### PR TITLE
Hide instructions initially and show them after download

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -407,7 +407,7 @@
 			<h2><a href="#instructions" onclick="descargarYScroll()">Descargar</a></h2>
 		</div>
 		<div style="height: 400px;"></div>
-		<div class="content">
+		<div class="content" id="instructions-section" style="display: none;">
 			<h3 id="instructions">Instrucciones de instalación:</h3>
 		<img src="instructions1.png" style="width: calc(30vw - 4rem); max-width: 100%; margin: 0;" />
 		<img src="instructions2.png" style="width: calc(100vw - 4rem); max-width: 100%; margin: 0;" />
@@ -423,6 +423,12 @@
 	      document.body.appendChild(enlaceDescarga);
 	      enlaceDescarga.click();
 	      document.body.removeChild(enlaceDescarga);
+	      
+	      // Muestra las instrucciones
+	      document.getElementById('instructions-section').style.display = 'block';
+	      
+	      // Hace scroll a las instrucciones
+	      document.getElementById('instructions').scrollIntoView({ behavior: 'smooth' });
 	    }
 	  </script>
 </body>


### PR DESCRIPTION
- Instructions section is now hidden by default (display: none)
- Instructions appear when user clicks the download button
- Added smooth scroll to instructions after they become visible
- Improves user experience by showing download first, then instructions

🤖 Generated with [Claude Code](https://claude.ai/code)